### PR TITLE
Compile Mitten with Menhir 20220210 and Cmdliner 1.1

### DIFF
--- a/mitten.opam
+++ b/mitten.opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/logsem/mitten.git"
 license: "MIT"
 depends: [
   "dune"  {build}
-  "cmdliner" {>= "1.0.2"}
+  "cmdliner" {>= "1.1.0"}
   "sexplib" {>= "0.11.0"}
   "ppx_compare" {>= "0.14"}
 ]

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -19,9 +19,9 @@ let input_file =
 
 let info =
   let doc = "Typecheck and normalize terms in MTT" in
-  let err_exit = Term.exit_info ~doc:"on an ill-formed or terms." 1 in
-  Term.info "mitten" ~version:"0.0" ~doc ~exits:(err_exit :: Term.default_exits)
+  let err_exit = Cmd.Exit.info ~doc:"on an ill-formed or terms." 1 in
+  Cmd.info "mitten" ~version:"0.0" ~doc ~exits:(err_exit :: Cmd.Exit.defaults)
 
 let () =
   let t = Term.(const main $ input_file) in
-  Term.exit_status @@ Term.eval (t, info)
+  exit @@ Cmd.eval' @@ Cmd.v info t

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,5 +1,5 @@
 (menhir
- (flags --explain --interpret-show-cst --table)
+ (flags --explain --table)
  (modules grammar))
 
 (ocamllex lex)


### PR DESCRIPTION
This PR fixes compile-time and run-time errors I've encountered when trying to run Mitten on top of an up-to-date OPAM ecosystem:
- compilation fails because it uses a deprecated part of Cmdliner's API, and dune makes such warnings fatal by default, and
-  the Menhir-generated parser fails at runtime with an assertion failure.

Regarding the second issue, I've been lazy and simply disabled the option `--interpret-show-cst` that is guilty. If this option is really needed, I could spend some time investigating the assertion failure.